### PR TITLE
Specify git ref (to prevent risks of non update BuildConfig object)

### DIFF
--- a/ansible/roles/epfl.search-inside/tasks/main.yml
+++ b/ansible/roles/epfl.search-inside/tasks/main.yml
@@ -27,6 +27,7 @@
     git:
       repository: "{{ searchinside_git_uri }}"
       path: docker_elasticsearch
+      ref: main
     strategy:
       dockerStrategy:
         env:
@@ -188,6 +189,7 @@
     git:
       repository: "{{ searchinside_git_uri }}"
       path: docker_nodeapi
+      ref: main
   register: _openshift_image_search_inside_nodeapi
 
 - name: NodeJS api - Rebuild image


### PR DESCRIPTION
**Description**

If the 'ref' is not specified, and we specify a 'ref' for testing. After this, we drop the 'ref' line, then there are no changes in the task, and the BuildConfig is not updated.