### PR TITLE
Implement retries on index a media

### DIFF
--- a/docker_elasticsearch/build_index.js
+++ b/docker_elasticsearch/build_index.js
@@ -460,7 +460,6 @@ const build = async () => {
   await setKibanaPassword();
   await indexAllPages();
   await indexAllMedias();
-  await delay(2000);
   console.log('\nIndex successfully created.\n');
   console.log('*********************************************************');
   console.timeEnd('Duration');


### PR DESCRIPTION
Fix #23 

Apparently ElasticSearch can't keep up with the indexing rate.

> When it happens, you should pause indexing a bit before trying again

See https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html#multiple-workers-threads
