### PR TITLE
Use Tekton pipeline only on test environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Deploy
 ------
 
 ```bash
-./ansible/elasticsible       # (--prod for deploy in production environment)
+./ansible/elasticsible     # (--prod for deploy in production environment)
 ```
 
 ## Search Inside API
@@ -57,7 +57,7 @@ Start a new build and restart the pods
 
 ```bash
 ./ansible/elasticsible -t api.image.startbuild
-./ansible/elasticsible -t api.image.restart
+./ansible/elasticsible -t api.image.restart     # (--prod for production environment)
 ```
 
 ## Search Inside Elastic
@@ -66,7 +66,7 @@ Start a new build and restart the pods
 
 ```bash
 ./ansible/elasticsible -t elastic.image.startbuild
-./ansible/elasticsible -t elastic.image.restart
+./ansible/elasticsible -t elastic.image.restart     # (--prod for production environment)
 ```
 
 You can also run the Tekton pipeline via Ansible

--- a/ansible/roles/epfl.search-inside/tasks/elastic/prod-daily-rollout.yml
+++ b/ansible/roles/epfl.search-inside/tasks/elastic/prod-daily-rollout.yml
@@ -1,0 +1,64 @@
+- name: Elastic/Prod Daily Rollout - Role
+  when:
+    - inventory_environment == "prod"
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: search-inside-elastic-role
+        namespace: "{{ openshift_namespace }}"
+      rules:
+        - apiGroups: ["apps"]
+          resources: ["deployments"]
+          verbs: ["get", "update", "patch"]
+
+- name: Elastic/Prod Daily Rollout - RoleBinding
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: search-inside-elastic-rolebinding
+        namespace: "{{ openshift_namespace }}"
+      subjects:
+        - kind: ServiceAccount
+          name: search-inside-elastic
+          namespace: "{{ openshift_namespace }}"
+      roleRef:
+        kind: Role
+        name: search-inside-elastic-role
+        apiGroup: rbac.authorization.k8s.io
+
+- name: Elastic/Prod Daily Rollout - CronJob
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: search-inside-elastic-daily-refresh
+        namespace: "{{ openshift_namespace }}"
+      spec:
+        schedule: "45 3 * * *"
+        jobTemplate:
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                serviceAccountName: search-inside-elastic
+                restartPolicy: Never
+                containers:
+                  - name: trigger-oc-rollout
+                    image: "{{ oc_cli_image }}"
+                    command:
+                      - /bin/sh
+                      - -c
+                      - |
+                        oc rollout restart deployments search-inside-elastic
+                    resources:
+                      requests:
+                        cpu: "100m"
+                        memory: "128Mi"
+                      limits:
+                        cpu: "250m"
+                        memory: "256Mi"

--- a/ansible/roles/epfl.search-inside/tasks/elastic/tekton-rbac.yml
+++ b/ansible/roles/epfl.search-inside/tasks/elastic/tekton-rbac.yml
@@ -1,4 +1,4 @@
-- name: Elastic/Tekton RBAC - Role for test (with build)
+- name: Elastic/Tekton RBAC - Role
   when:
     - inventory_environment == "test"
   kubernetes.core.k8s:
@@ -21,24 +21,6 @@
         - apiGroups: ["build.openshift.io"]
           resources: ["builds/log"]
           verbs: ["get"]
-        - apiGroups: ["apps"]
-          resources: ["deployments"]
-          verbs: ["get", "update", "patch"]
-        - apiGroups: ["tekton.dev"]
-          resources: ["pipelineruns"]
-          verbs: ["create", "get", "list", "patch"]
-
-- name: Elastic/Tekton RBAC - Role for prod (without build)
-  when:
-    - inventory_environment == "prod"
-  kubernetes.core.k8s:
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: Role
-      metadata:
-        name: search-inside-elastic-builder-role
-        namespace: "{{ openshift_namespace }}"
-      rules:
         - apiGroups: ["apps"]
           resources: ["deployments"]
           verbs: ["get", "update", "patch"]

--- a/ansible/roles/epfl.search-inside/tasks/elastic/tekton.yml
+++ b/ansible/roles/epfl.search-inside/tasks/elastic/tekton.yml
@@ -1,6 +1,4 @@
-- name: Elastic/Tekton - Task/Build Elastic (on test)
-  when:
-    - inventory_environment == "test"
+- name: Elastic/Tekton - Task/Build Elastic
   kubernetes.core.k8s:
     definition:
       apiVersion: tekton.dev/v1beta1
@@ -34,9 +32,7 @@
               oc rollout restart deployments search-inside-elastic
   changed_when: false
 
-- name: Elastic/Tekton - Pipeline on test (build + restart)
-  when:
-    - inventory_environment == "test"
+- name: Elastic/Tekton - Pipeline
   kubernetes.core.k8s:
     definition:
       apiVersion: tekton.dev/v1beta1
@@ -57,22 +53,6 @@
               name: restart-elastic
   changed_when: false
 
-- name: Elastic/Tekton - Pipeline on prod (restart)
-  when:
-    - inventory_environment == "prod"
-  kubernetes.core.k8s:
-    definition:
-      apiVersion: tekton.dev/v1beta1
-      kind: Pipeline
-      metadata:
-        name: restart-elastic
-        namespace: "{{ openshift_namespace }}"
-      spec:
-        tasks:
-          - name: restart-elastic
-            taskRef:
-              name: restart-elastic
-
 - name: Elastic/Tekton - CronJob
   kubernetes.core.k8s:
     definition:
@@ -82,7 +62,7 @@
         name: run-pipeline-elastic
         namespace: "{{ openshift_namespace }}"
       spec:
-        schedule: "{{ '25 1 * * *' if inventory_environment == 'test' else '45 3 * * *' }}"
+        schedule: "25 1 * * *"
         jobTemplate:
           spec:
             backoffLimit: 0
@@ -107,10 +87,10 @@
                           timeout: "2h"
                           serviceAccountName: search-inside-elastic-builder
                           pipelineRef:
-                            name: "{{ 'build-and-' if inventory_environment == 'test' else '' }}restart-elastic"
+                            name: "build-and-restart-elastic"
                         EOF
 
-- name: Elastic/Tekton - Run pipeline (test or prod)
+- name: Elastic/Tekton - Run pipeline
   when: >-
     "elastic.tekton.run-pipeline" in ansible_run_tags
   kubernetes.core.k8s:
@@ -124,5 +104,5 @@
         timeout: "2h"
         serviceAccountName: search-inside-elastic-builder
         pipelineRef:
-          name: "{{ 'build-and-' if inventory_environment == 'test' else '' }}restart-elastic"
+          name: "build-and-restart-elastic"
   tags: elastic.tekton.run-pipeline

--- a/ansible/roles/epfl.search-inside/tasks/main.yml
+++ b/ansible/roles/epfl.search-inside/tasks/main.yml
@@ -49,6 +49,8 @@
     - elastic.app.restart
 
 - name: Elastic - Tekton RBAC
+  when:
+    - inventory_environment == "test"
   include_tasks:
     file: 'elastic/tekton-rbac.yml'
     apply:
@@ -60,6 +62,8 @@
     - elastic.tekton-rbac
 
 - name: Elastic - Tekton
+  when:
+    - inventory_environment == "test"
   include_tasks:
     file: 'elastic/tekton.yml'
     apply:
@@ -70,6 +74,19 @@
     - elastic
     - elastic.tekton
     - elastic.tekton.run-pipeline
+
+- name: Elastic - Prod Daily Rollout
+  when:
+    - inventory_environment == "prod"
+  include_tasks:
+    file: 'elastic/prod-daily-rollout.yml'
+    apply:
+      tags:
+        - elastic
+        - elastic.prod-daily-rollout
+  tags:
+    - elastic
+    - elastic.prod-daily-rollout
 
 - name: Monitoring
   include_tasks:


### PR DESCRIPTION
**Description**

Tekton will be used exclusively in the test environment, as it is not installed in production. This also simplifies the deployment process in production, where the pipeline only contained a single task that executed `oc` command.

By removing the pipeline from production, we reduce complexity and avoid dependencies on Tekton where it's not needed.