### PR TITLE
Fix build failure alert

### DIFF
--- a/ansible/roles/epfl.search-inside/tasks/monitoring.yml
+++ b/ansible/roles/epfl.search-inside/tasks/monitoring.yml
@@ -109,9 +109,9 @@
                     "The most recent build for search-inside-elastic is older than 30 hours."
               - alert: SearchInsideElasticBuildFailure
                 expr: >
-                  increase(openshift_build_status_phase_total{
+                  changes(openshift_build_status_phase_total{
                     build_phase=~"failed|error", namespace="{{ openshift_namespace }}", buildconfig="search-inside-elastic"
-                  }[2m]) > 0
+                  }[10m]) > 0
                 for: 1m
                 labels:
                   severity: warning


### PR DESCRIPTION
The alert expression using `increase` missed the last 3 build failures. 
Switching to `changes` appears to be a better approach.

![Selection_137](https://github.com/user-attachments/assets/cf8e3a2a-558d-4faf-82a0-e142e322fef7)

