### PR TITLE
Fix Prometheus rules (rollout verification on test/prod)

### DIFF
--- a/ansible/roles/epfl.search-inside/tasks/monitoring.yml
+++ b/ansible/roles/epfl.search-inside/tasks/monitoring.yml
@@ -122,20 +122,6 @@
                   description: "The build of search-inside-elastic has failed or encountered an error."
           - name: rollout-alerts
             rules:
-              - alert: SearchInsideElasticNoRollout
-                expr: >
-                  increase(kube_deployment_status_observed_generation{
-                    namespace="{{ openshift_namespace }}", deployment="search-inside-elastic"
-                  }[24h]) < 1
-                for: 1m
-                labels:
-                  severity: warning
-                  sendto: telegram
-                annotations:
-                  summary: "No rollout detected for search-inside-elastic"
-                  description: >-
-                    "The deployment search-inside-elastic in the namespace "{{ openshift_namespace }}"
-                    hasn't changed (rollout) in the last 24 hours."
               - alert: SearchInsideElasticPodOlderThan30H
                 expr: >
                   (time() -


### PR DESCRIPTION
2 changes:
* Fix rule `SearchInsideElasticPodOlderThan30H`
* Remove rule `SearchInsideElasticNoRollout` as unstable and a bit redundant with `SearchInsideElasticPodOlderThan30H`